### PR TITLE
feat: Add ftdetect for norg filetype

### DIFF
--- a/ftdetect/norg.vim
+++ b/ftdetect/norg.vim
@@ -1,0 +1,1 @@
+autocmd BufRead,BufNewFile *.norg setlocal filetype=norg


### PR DESCRIPTION
> Worried about lazy loading? It's very hard to do properly because of the way Neovim handles filetypes. I'm planning on adding a PR with support for Neorg files to the Neovim core at some point. 

Support in core isn't necessary for this. You can just add ftdetect for norg format and it'll work .Package managers to execute ftdetect files for lazyloaded plugins too . Lua is suported in core for ftdetect but not all plugin managers have support yet. For example packer doesn't yet run lua ftdetect files for lazyloading . It's planned though https://github.com/wbthomason/packer.nvim/issues/403