### PR TITLE
Boot up Neorg on Bufnew

### DIFF
--- a/lua/neorg.lua
+++ b/lua/neorg.lua
@@ -24,7 +24,7 @@ function neorg.setup(config)
 	else
 		-- Else listen for a BufRead event and fire up the Neorg environment then
 		vim.cmd [[
-			autocmd BufRead *.norg ++once :lua vim.opt_local.filetype = "norg"; require('neorg').org_file_entered()
+			autocmd BufRead,BufNew *.norg ++once :lua vim.opt_local.filetype = "norg"; require('neorg').org_file_entered()
 			command! -nargs=0 Neorg delcommand Neorg | lua require('neorg').org_file_entered()
 		]]
 	end


### PR DESCRIPTION
Right now if you `nvim test.norg` it opens up a new file and inserts the `@document.meta` at the top. Similarly, if you open nvim and then `:e existing_file.norg` it will do the same. However, if you open up nvim and `:e new_file.norg`, Neorg is not initialized and the file does not get the `@document.meta`