### PR TITLE
Fix #53

### DIFF
--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -408,7 +408,7 @@ module.public = {
                     'syn region NeorgConcealURLValue matchgroup=mkdDelimiter start="(" end=")" contained oneline conceal'
                 )
                 vim.cmd(
-                    'syn region NeorgConcealURL matchgroup=mkdDelimiter start="[^\\\\]\\@<=\\[\\%\\(\\%\\(\\\\\\=[^\\]]\\)\\+\\](\\)\\@=" end="[^\\\\]\\@<=\\]" nextgroup=NeorgConcealURLValue oneline skipwhite concealends'
+                    'syn region NeorgConcealURL matchgroup=mkdDelimiter start="\\([^\\\\]\\|\\_^\\)\\@<=\\[\\%\\(\\%\\(\\\\\\=[^\\]]\\)\\+\\](\\)\\@=" end="[^\\\\]\\@<=\\]" nextgroup=NeorgConcealURLValue oneline skipwhite concealends'
                 )
             end)
         end


### PR DESCRIPTION
Until the TS parser supports attached modifiers this will fix
highlighting and concealing of links starting at the beginning of a
line.

![screenshot_1630153596](https://user-images.githubusercontent.com/21973473/131217879-4a9e4c71-fdbc-4708-a177-b5ae48d990ba.png)
